### PR TITLE
fix: auto-generate minimal config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "clap",
  "directories",
  "env_logger",
+ "indoc",
  "log",
  "opzioni",
  "serde",
@@ -327,6 +328,12 @@ dependencies = [
  "autocfg",
  "hashbrown",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2cb48b81b1dc9f39676bf99f5499babfec7cd8fe14307f7b3d747208fb5690"
 
 [[package]]
 name = "io-lifetimes"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ thiserror = "1"
 toml = "0.7.4"
 directories = "5.0.1"
 tracing = "0.1.37"
+indoc = "2"
 opzioni = { version = "0.1.3", default-features = false, features = [
     "toml",
     "tracing",

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ You can always use the `.` path to specify the current directory.
 - [x] Add support for config file
 - [x] Add support for custom file types
 - [x] Add support for custom folders
+- [x] Automatically create config file if it does not exist
 - [ ] Add support for subdirectories
 - [ ] Add colors to the output
 - [ ] Add installers

--- a/desktop-cleaner.code-workspace
+++ b/desktop-cleaner.code-workspace
@@ -61,6 +61,7 @@
       "flac",
       "FOLDERID",
       "froms",
+      "indoc",
       "mobi",
       "onedrive",
       "opzioni",

--- a/docs/.desktop_cleaner.toml
+++ b/docs/.desktop_cleaner.toml
@@ -1,17 +1,17 @@
 # REQUIRED: specify the name of the folders mapped to each file type
 [file_types]
-NOTES = [".md", ".rtf", ".txt"]
-DOCS = [".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx"]
+Notes = [".md", ".rtf", ".txt"]
+Docs = [".doc", ".docx", ".xls", ".xlsx", ".ppt", ".pptx"]
 EXE = [".exe", ".appimage", ".msi"]
-VIDS = [".mp4", ".mov", ".avi", ".mkv"]
-COMPRESSED = [".zip", ".rar", ".tar", ".gz", ".7z"]
-SCRIPTS = [".sh", ".bat"]
-INSTALLERS = [".deb", ".rpm"]
-BOOKS = [".epub", ".mobi"]
-MUSIC = [".mp3", ".wav", ".ogg", ".flac"]
+Vids = [".mp4", ".mov", ".avi", ".mkv"]
+Compressed = [".zip", ".rar", ".tar", ".gz", ".7z"]
+Scripts = [".sh", ".bat"]
+Installers = [".deb", ".rpm"]
+Books = [".epub", ".mobi"]
+Music = [".mp3", ".wav", ".ogg", ".flac"]
 PDFS = [".pdf"]
-PICS = [".bmp", ".gif", ".jpg", ".jpeg", ".svg", ".png"]
-TORRENTS = [".torrent"]
+Pics = [".bmp", ".gif", ".jpg", ".jpeg", ".svg", ".png"]
+Torrents = [".torrent"]
 CODE = [
     ".c",
     ".h",
@@ -37,7 +37,7 @@ CODE = [
     ".m",
     ".asm",
 ]
-MARKUP = [
+Markup = [
     ".json",
     ".xml",
     ".yml",
@@ -51,4 +51,4 @@ MARKUP = [
 
 # OPTIONAL: debug level for stdout logging. if not specified, defaults to "off"
 [debug]
-LEVEL = "info" # "info", "debug", "warn", "error", "trace", "off"
+level = "info" # "info", "debug", "warn", "error", "trace", "off"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,4 +1,4 @@
-use clap::{Args, Parser, Subcommand};
+use clap::Parser;
 
 #[derive(Parser, Debug)]
 #[clap(author, version, about)]
@@ -12,23 +12,3 @@ pub struct DesktopCleanerArgs {
     #[clap(long, short, action)]
     pub recursive: Option<bool>,
 }
-
-/* #[derive(Subcommand, Debug)]
-pub enum EntityType {
-    /// Grab the directory to clean
-    /// if none is provided we will use the default for your desktop
-    Clean(DirectoryCommand),
-}
-
-#[derive(Args, Debug)]
-#[group(required = false, multiple = false)]
-pub struct DirectoryCommand {
-    /// The directory to clean
-    pub directory: Option<String>,
-    /// Whether or not to include hidden files
-    #[clap(long, short, action)]
-    pub hidden: Option<bool>,
-    /// Whether or not to include subdirectories
-    #[clap(long, short, action)]
-    pub recursive: Option<bool>,
- */

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,10 +47,10 @@ fn main() -> Result<()> {
         String::from("")
     });
 
-    let mut recursive = cli_args.recursive.unwrap_or_else(|| {
+    /* let mut recursive = cli_args.recursive.unwrap_or_else(|| {
         debug!("No Args passed for recursive, will  ignore subdirectories");
         false
-    });
+    }); */
 
     /* let mut hidden = cli_args.hidden.unwrap_or_else(|| {
         debug!("No Args passed for hidden, will not ignore hidden files");


### PR DESCRIPTION
- auto-create config dir if none exists
- auto-create minimal config file if none exists
- update readme
- use lower-case debug level
- remove compile warnings